### PR TITLE
feat: improve Linux pyenv install (staff-grade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ cd foundry-bootstrap
 
 The script installs the required package manager (Homebrew on macOS or apt on Linux), pyenv, Python and pipx. It then delegates to `orchestrate/main.py` to install everything defined in the YAML files. If an apt package is unavailable the orchestrator now tries a small fallback installer (for example a curl script) and still records the item in `TODO.md`. At the end `test_setup.py` verifies the tools are available.
 
+When running on Linux the bootstrapper installs the build dependencies needed by
+pyenv. Set the environment variable `PYENV_ARCHIVE` to the path of a tarball
+containing a cloned `pyenv` repository to perform the installation without
+network access. Use `PYENV_SKIP_DEPS=1` to skip the dependency step if required.
+
 ## Configuration
 
 - `config/packages.yaml` – system packages with optional apt overrides

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,8 @@
 # TODO
 
 - [x] Confirm apt package names for all tools and ensure installation for packages unavailable via apt.
-- [ ] Improve Linux pyenv installation (handle dependencies, offline archives).
+- [x] Improve Linux pyenv installation (handle dependencies, offline archives).
 - [ ] Add support for additional package managers or distributions beyond Debian-based.
 - [ ] Automate installation of PyYAML or switch to pure bash parsing to avoid dependency during bootstrapping.
 - [ ] Resolve network restrictions for package installation in container environments.
+- [ ] Add apt installation method for just

--- a/docs/design-pyenv-linux.md
+++ b/docs/design-pyenv-linux.md
@@ -1,0 +1,33 @@
+# Design: improved pyenv installation on Linux
+
+## Rationale
+The existing `install/install_pyenv_linux.sh` script simply clones the
+`pyenv` repository from GitHub. It does not install the build dependencies
+needed for Python versions managed by pyenv and fails when run in an
+environment without network access. The TODO asks to improve this script so
+that pyenv can be installed together with its dependencies and from an
+offline archive when available.
+
+## Approach
+1. Install the common build dependencies via `apt-get` when available.
+   The installation can be skipped by setting `PYENV_SKIP_DEPS=1` which is
+   helpful for test environments.
+2. Support an optional environment variable `PYENV_ARCHIVE` pointing to a
+   tarball containing a pre‑cloned pyenv repository. When provided the
+   archive is extracted into `$HOME/.pyenv` instead of performing a `git`
+   clone. This allows offline bootstrapping.
+3. Keep the rest of the setup (updating `PATH` and shell configuration)
+   unchanged.
+
+## Touchpoints
+```
+install/install_pyenv_linux.sh  # add deps and offline support
+README.md                       # document PYENV_ARCHIVE usage
+tests/test_pyenv_offline.py     # new test exercising archive path
+TODO.md                         # mark task complete
+```
+
+## Alternatives considered
+- Embedding the pyenv source directly in the repository. Rejected to keep the
+  repo lightweight.
+- Installing dependencies with another package manager. Out of scope for now.

--- a/install/install_pyenv_linux.sh
+++ b/install/install_pyenv_linux.sh
@@ -1,20 +1,36 @@
 #!/bin/bash
 set -euo pipefail
 
-# Install pyenv on Linux using git checkout
+# Install pyenv on Linux with dependency handling and optional offline archive
 if command -v pyenv &>/dev/null; then
     echo "✅ pyenv already installed"
     exit 0
 fi
 
-if ! command -v git &>/dev/null; then
-    echo "❌ git not found. Please install git first."
-    exit 1
-fi
-
 PYENV_ROOT="$HOME/.pyenv"
 
-git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT"
+# Install build dependencies unless explicitly skipped
+if command -v apt-get &>/dev/null && [[ -z "${PYENV_SKIP_DEPS:-}" ]]; then
+    DEPS=(
+        make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev
+        libsqlite3-dev curl llvm libncursesw5-dev xz-utils tk-dev libxml2-dev
+        libxmlsec1-dev libffi-dev liblzma-dev
+    )
+    apt-get update
+    apt-get install -y "${DEPS[@]}"
+fi
+
+# Use local archive when provided, otherwise clone from GitHub
+if [[ -n "${PYENV_ARCHIVE:-}" && -f "$PYENV_ARCHIVE" ]]; then
+    mkdir -p "$PYENV_ROOT"
+    tar -xzf "$PYENV_ARCHIVE" -C "$PYENV_ROOT" --strip-components=1
+else
+    if ! command -v git &>/dev/null; then
+        echo "❌ git not found. Please install git first."
+        exit 1
+    fi
+    git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT"
+fi
 
 export PYENV_ROOT="$PYENV_ROOT"
 export PATH="$PYENV_ROOT/bin:$PATH"

--- a/tests/test_pyenv_offline.py
+++ b/tests/test_pyenv_offline.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tarfile
+from pathlib import Path
+
+
+def test_install_pyenv_offline(tmp_path):
+    repo_root = Path(__file__).resolve().parent.parent
+    script = repo_root / "install" / "install_pyenv_linux.sh"
+
+    # create minimal pyenv archive
+    pyenv_src = tmp_path / "src" / "pyenv" / "bin"
+    pyenv_src.mkdir(parents=True)
+    fake = pyenv_src / "pyenv"
+    fake.write_text("#!/bin/sh\necho pyenv")
+    fake.chmod(0o755)
+
+    archive = tmp_path / "pyenv.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(pyenv_src.parent, arcname="pyenv")
+
+    env = {
+        "HOME": str(tmp_path),
+        "PYENV_ARCHIVE": str(archive),
+        "PYENV_SKIP_DEPS": "1",
+        "PATH": "/usr/bin:/bin",
+    }
+
+    subprocess.run(["bash", str(script)], check=True, env=env)
+
+    assert (tmp_path / ".pyenv" / "bin" / "pyenv").exists()


### PR DESCRIPTION
## Summary
- handle dependencies and offline archive in `install_pyenv_linux.sh`
- document design for Linux pyenv improvements
- mention new PYENV_ARCHIVE and PYENV_SKIP_DEPS options in README
- mark TODO item complete
- test offline install path

## Design Rationale
Adds an optional environment variable to allow pyenv installation from a local
archive and installs common build deps via apt. Dependencies can be skipped with
`PYENV_SKIP_DEPS` for CI tests. This keeps the script lightweight but works
without network access.

## Risks
- List of apt packages may not match all distros
- Extraction assumes a tar.gz archive layout similar to the pyenv repo

## Testing
- `ruff check .`
- `mypy --explicit-package-bases orchestrate/main.py tests/test_fallback.py tests/test_pyenv_offline.py test_setup.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b08e6cb9483238a41031142cbd9f2